### PR TITLE
feat: authly_connect protocol

### DIFF
--- a/crates/authly-common/build.rs
+++ b/crates/authly-common/build.rs
@@ -1,7 +1,10 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .protoc_arg("--experimental_allow_proto3_optional")
-        .compile_protos(&["proto/authly_service.proto"], &["proto/"])?;
+        .compile_protos(
+            &["proto/authly_connect.proto", "proto/authly_service.proto"],
+            &["proto/"],
+        )?;
 
     println!("cargo:rerun-if-changed=build.rs");
 

--- a/crates/authly-common/proto/authly_connect.proto
+++ b/crates/authly-common/proto/authly_connect.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package authly_connect;
+
+// Authly Connect protocol
+service AuthlyConnect {
+    // Make a tunnel to the Authly instance.
+    rpc Tunnel (stream Frame) returns (stream Frame);
+}
+
+// A frame sent over the connection.
+message Frame {
+    // The byte buffer contained in this Frame's payload.
+    bytes payload = 1;
+}

--- a/crates/authly-common/src/proto.rs
+++ b/crates/authly-common/src/proto.rs
@@ -1,5 +1,10 @@
 //! Authly protobuf types.
 
+/// Tonic types for the `authly_connect` protobuf definition.
+pub mod connect {
+    tonic::include_proto!("authly_connect");
+}
+
 /// Tonic types for the `authly_service` protobuf definition.
 pub mod service {
     tonic::include_proto!("authly_service");


### PR DESCRIPTION
It's a tunnel protocol for making end-to-end TLS connection between two Authly instances over the internet or insecure channels.