### PR TITLE
feat: messaging from authly to client, background worker

### DIFF
--- a/crates/authly-client/CHANGELOG.md
+++ b/crates/authly-client/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Background worker with auto-reconnect and messaging system
 
 ## [0.0.4] - 2025-01-27
 ### Changed

--- a/crates/authly-client/Cargo.toml
+++ b/crates/authly-client/Cargo.toml
@@ -30,5 +30,6 @@ rustls-pki-types = "1"
 thiserror = "2"
 time = "0.3"
 tonic = { version = "0.12", default-features = false, features = ["tls"] }
+tokio = { version = "1", features = ["macros"] }
 tracing = "0.1"
 x509-parser = "0.16"

--- a/crates/authly-client/src/background_worker.rs
+++ b/crates/authly-client/src/background_worker.rs
@@ -67,6 +67,15 @@ async fn handle_message_kind(
         proto::service_message::ServiceMessageKind::ReloadCache(_) => {
             reload_local_cache(state).await;
         }
+        proto::service_message::ServiceMessageKind::Ping(_) => {
+            let _result = state
+                .conn
+                .load()
+                .authly_service
+                .clone()
+                .pong(tonic::Request::new(proto::Empty {}))
+                .await;
+        }
     }
 }
 

--- a/crates/authly-client/src/background_worker.rs
+++ b/crates/authly-client/src/background_worker.rs
@@ -1,0 +1,124 @@
+use std::{sync::Arc, time::Duration};
+
+use authly_common::proto::service::{self as proto};
+use tonic::Streaming;
+
+use crate::{access_control, connection::make_connection, error, ClientState, Error};
+
+pub async fn spawn_background_worker(
+    state: Arc<ClientState>,
+    closed_rx: tokio::sync::watch::Receiver<()>,
+) -> Result<(), Error> {
+    let msg_stream = init_message_stream(&state).await?;
+    tokio::spawn(background_worker(state, closed_rx, msg_stream));
+
+    Ok(())
+}
+
+async fn background_worker(
+    state: Arc<ClientState>,
+    mut closed_rx: tokio::sync::watch::Receiver<()>,
+    mut msg_stream: Streaming<proto::ServiceMessage>,
+) {
+    loop {
+        tokio::select! {
+            msg_result = msg_stream.message() => {
+                handle_message_result(&state, msg_result, &mut msg_stream).await;
+            }
+            _ = closed_rx.changed() => {
+                tracing::info!("Authly channel closed");
+                return;
+            }
+        }
+    }
+}
+
+async fn handle_message_result(
+    state: &ClientState,
+    msg_result: Result<Option<proto::ServiceMessage>, tonic::Status>,
+    msg_stream: &mut Streaming<proto::ServiceMessage>,
+) {
+    match msg_result {
+        Ok(Some(msg)) => {
+            if let Some(kind) = msg.service_message_kind {
+                handle_message_kind(state, kind, msg_stream).await;
+            }
+        }
+        Ok(None) => {
+            reconfigure_loop(state, msg_stream).await;
+        }
+        Err(_error) => {
+            reconfigure_loop(state, msg_stream).await;
+        }
+    }
+}
+
+async fn handle_message_kind(
+    state: &ClientState,
+    msg_kind: proto::service_message::ServiceMessageKind,
+    msg_stream: &mut Streaming<proto::ServiceMessage>,
+) {
+    tracing::info!(?msg_kind, "Received Authly message");
+
+    match msg_kind {
+        proto::service_message::ServiceMessageKind::ReloadCa(_) => {
+            reconfigure_loop(state, msg_stream).await;
+        }
+        proto::service_message::ServiceMessageKind::ReloadCache(_) => {
+            reload_local_cache(state).await;
+        }
+    }
+}
+
+async fn reconfigure_loop(state: &ClientState, msg_stream: &mut Streaming<proto::ServiceMessage>) {
+    loop {
+        match try_reconfigure(state, msg_stream).await {
+            Ok(()) => return,
+            Err(err) => {
+                tracing::error!(?err, "background reconfigure error");
+
+                tokio::time::sleep(Duration::from_secs(10)).await;
+            }
+        }
+    }
+}
+
+async fn try_reconfigure(
+    state: &ClientState,
+    msg_stream: &mut Streaming<proto::ServiceMessage>,
+) -> Result<(), Error> {
+    let connection_params = state.reconfigure.new_connection_params().await?;
+    let connection = Arc::new(make_connection(connection_params).await?);
+
+    state.conn.store(connection.clone());
+
+    *msg_stream = init_message_stream(state).await?;
+    reload_local_cache(state).await;
+
+    Ok(())
+}
+
+async fn init_message_stream(
+    state: &ClientState,
+) -> Result<Streaming<proto::ServiceMessage>, Error> {
+    let mut current_service = state.conn.load().authly_service.clone();
+    let response = current_service
+        .messages(tonic::Request::new(proto::Empty {}))
+        .await
+        .map_err(error::tonic)?;
+
+    Ok(response.into_inner())
+}
+
+async fn reload_local_cache(state: &ClientState) {
+    match access_control::get_resource_property_mapping(state.conn.load().authly_service.clone())
+        .await
+    {
+        Ok(property_mapping) => {
+            state.resource_property_mapping.store(property_mapping);
+        }
+        Err(err) => {
+            tracing::error!(?err, "failed to reload resource property mapping");
+        }
+    }
+}

--- a/crates/authly-client/src/builder.rs
+++ b/crates/authly-client/src/builder.rs
@@ -1,27 +1,135 @@
 use std::{borrow::Cow, sync::Arc};
 
 use arc_swap::ArcSwap;
-use authly_common::proto::service::authly_service_client::AuthlyServiceClient;
 use http::header::AUTHORIZATION;
 use pem::{EncodeConfig, Pem};
 use rcgen::KeyPair;
 
 use crate::{
-    access_control, error, identity::Identity, Client, ClientInner, Error, IDENTITY_PATH,
-    K8S_SA_TOKENFILE_PATH, LOCAL_CA_CERT_PATH,
+    access_control,
+    background_worker::spawn_background_worker,
+    connection::{make_connection, ConnectionParams, ReconfigureStrategy},
+    error,
+    identity::Identity,
+    Client, ClientState, Error, IDENTITY_PATH, K8S_SA_TOKENFILE_PATH, LOCAL_CA_CERT_PATH,
 };
+
+#[derive(Clone, Copy)]
+pub(crate) enum Inference {
+    Inferred,
+    Manual,
+}
 
 /// A builder for configuring a [Client].
 pub struct ClientBuilder {
-    pub(crate) authly_local_ca: Option<Vec<u8>>,
-    pub(crate) identity: Option<Identity>,
-    pub(crate) jwt_decoding_key: Option<jsonwebtoken::DecodingKey>,
-    pub(crate) url: Cow<'static, str>,
+    pub(crate) inner: ConnectionParamsBuilder,
 }
 
 impl ClientBuilder {
     /// Infer the Authly client from the environment it runs in.
     pub async fn from_environment(mut self) -> Result<Self, Error> {
+        self.inner.infer().await?;
+        Ok(self)
+    }
+
+    /// Use the given CA certificate to verify the Authly server
+    pub fn with_authly_local_ca_pem(mut self, ca: Vec<u8>) -> Result<Self, Error> {
+        self.inner.inference = Inference::Manual;
+        self.inner.jwt_decoding_key = Some(jwt_decoding_key_from_cert(&ca)?);
+        self.inner.authly_local_ca = Some(ca);
+        Ok(self)
+    }
+
+    /// Use a pre-certified client identity
+    pub fn with_identity(mut self, identity: Identity) -> Self {
+        self.inner.inference = Inference::Manual;
+        self.inner.identity = Some(identity);
+        self
+    }
+
+    /// Override Authly URL (default is https://authly)
+    pub fn with_url(mut self, url: impl Into<String>) -> Self {
+        self.inner.url = url.into().into();
+        self
+    }
+
+    /// Get the current Authly local CA of the builder as a PEM-encoded byte buffer.
+    pub fn get_local_ca_pem(&self) -> Result<Cow<[u8]>, Error> {
+        self.inner
+            .authly_local_ca
+            .as_ref()
+            .map(|ca| Cow::Borrowed(ca.as_slice()))
+            .ok_or_else(|| Error::AuthlyCA("unconfigured"))
+    }
+
+    /// Get the current Authly identity of the builder as a PEM-encoded byte buffer.
+    pub fn get_identity_pem(&self) -> Result<Cow<[u8]>, Error> {
+        let identity = self
+            .inner
+            .identity
+            .as_ref()
+            .ok_or_else(|| Error::Identity("unconfigured"))?;
+
+        let mut identity_pem = identity.cert_pem.clone();
+        identity_pem.extend(&identity.key_pem);
+        Ok(Cow::Owned(identity_pem))
+    }
+
+    /// Connect to Authly
+    pub async fn connect(self) -> Result<Client, Error> {
+        let params = self.inner.try_into_connection_params()?;
+        let connection = make_connection(params.clone()).await?;
+
+        let reconfigure = match params.inference {
+            Inference::Inferred => ReconfigureStrategy::ReInfer {
+                url: params.url.clone(),
+            },
+            Inference::Manual => ReconfigureStrategy::Params(params),
+        };
+
+        let resource_property_mapping =
+            access_control::get_resource_property_mapping(connection.authly_service.clone())
+                .await?;
+
+        let (closed_tx, closed_rx) = tokio::sync::watch::channel(());
+        let state = Arc::new(ClientState {
+            conn: ArcSwap::new(Arc::new(connection)),
+            reconfigure,
+            closed_tx,
+            resource_property_mapping: ArcSwap::new(resource_property_mapping),
+        });
+
+        spawn_background_worker(state.clone(), closed_rx).await?;
+
+        let client = Client { state };
+
+        Ok(client)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ConnectionParamsBuilder {
+    pub inference: Inference,
+    pub url: Cow<'static, str>,
+    pub authly_local_ca: Option<Vec<u8>>,
+    pub identity: Option<Identity>,
+    pub jwt_decoding_key: Option<jsonwebtoken::DecodingKey>,
+}
+
+impl ConnectionParamsBuilder {
+    pub(crate) fn new(url: Cow<'static, str>) -> Self {
+        Self {
+            inference: Inference::Manual,
+            url,
+            authly_local_ca: None,
+            identity: None,
+            jwt_decoding_key: None,
+        }
+    }
+
+    /// Try to infer the parameters from the environment
+    pub(crate) async fn infer(&mut self) -> Result<(), Error> {
+        self.inference = Inference::Inferred;
         let authly_local_ca =
             std::fs::read(LOCAL_CA_CERT_PATH).map_err(|_| Error::AuthlyCAmissingInEtc)?;
         self.jwt_decoding_key = Some(jwt_decoding_key_from_cert(&authly_local_ca)?);
@@ -33,7 +141,7 @@ impl ClientBuilder {
                     .map_err(|_| Error::Identity("invalid identity"))?,
             );
 
-            Ok(self)
+            Ok(())
         } else if std::fs::exists(K8S_SA_TOKENFILE_PATH).unwrap_or(false) {
             let key_pair = KeyPair::generate().map_err(|_err| Error::PrivateKeyGen)?;
             let token =
@@ -68,55 +176,16 @@ impl ClientBuilder {
                 key_pem: key_pair.serialize_pem().into_bytes(),
             });
 
-            Ok(self)
+            Ok(())
         } else {
             Err(Error::EnvironmentNotInferrable)
         }
     }
 
-    /// Use the given CA certificate to verify the Authly server
-    pub fn with_authly_local_ca_pem(mut self, ca: Vec<u8>) -> Result<Self, Error> {
-        self.jwt_decoding_key = Some(jwt_decoding_key_from_cert(&ca)?);
-        self.authly_local_ca = Some(ca);
-        Ok(self)
-    }
-
-    /// Use a pre-certified client identity
-    pub fn with_identity(mut self, identity: Identity) -> Self {
-        self.identity = Some(identity);
-        self
-    }
-
-    /// Override Authly URL (default is https://authly)
-    pub fn with_url(mut self, url: impl Into<String>) -> Self {
-        self.url = url.into().into();
-        self
-    }
-
-    /// Get the current Authly local CA of the builder as a PEM-encoded byte buffer.
-    pub fn get_local_ca_pem(&self) -> Result<Cow<[u8]>, Error> {
-        self.authly_local_ca
-            .as_ref()
-            .map(|ca| Cow::Borrowed(ca.as_slice()))
-            .ok_or_else(|| Error::AuthlyCA("unconfigured"))
-    }
-
-    /// Get the current Authly identity of the builder as a PEM-encoded byte buffer.
-    pub fn get_identity_pem(&self) -> Result<Cow<[u8]>, Error> {
-        let identity = self
-            .identity
-            .as_ref()
-            .ok_or_else(|| Error::Identity("unconfigured"))?;
-
-        let mut identity_pem = identity.cert_pem.clone();
-        identity_pem.extend(&identity.key_pem);
-        Ok(Cow::Owned(identity_pem))
-    }
-
-    /// Connect to Authly
-    pub async fn connect(self) -> Result<Client, Error> {
+    pub fn try_into_connection_params(self) -> Result<Arc<ConnectionParams>, Error> {
         let authly_local_ca = self
             .authly_local_ca
+            .clone()
             .ok_or_else(|| Error::AuthlyCA("unconfigured"))?;
         let jwt_decoding_key = self
             .jwt_decoding_key
@@ -125,35 +194,17 @@ impl ClientBuilder {
             .identity
             .ok_or_else(|| Error::Identity("unconfigured"))?;
 
-        let tls_config = tonic::transport::ClientTlsConfig::new()
-            .ca_certificate(tonic::transport::Certificate::from_pem(&authly_local_ca))
-            .identity(tonic::transport::Identity::from_pem(
-                identity.cert_pem,
-                identity.key_pem,
-            ));
-
-        let endpoint = tonic::transport::Endpoint::from_shared(self.url.to_string())
-            .map_err(error::network)?
-            .tls_config(tls_config)
-            .map_err(error::network)?;
-
-        let service =
-            AuthlyServiceClient::new(endpoint.connect().await.map_err(error::unclassified)?);
-
-        let resource_property_mapping =
-            access_control::get_resource_property_mapping(service.clone()).await?;
-
-        Ok(Client {
-            inner: Arc::new(ClientInner {
-                authly_service: service,
-                jwt_decoding_key,
-                resource_property_mapping: Arc::new(ArcSwap::new(resource_property_mapping)),
-            }),
-        })
+        Ok(Arc::new(ConnectionParams {
+            inference: self.inference,
+            url: self.url,
+            authly_local_ca,
+            jwt_decoding_key,
+            identity,
+        }))
     }
 }
 
-fn jwt_decoding_key_from_cert(cert: &[u8]) -> Result<jsonwebtoken::DecodingKey, Error> {
+pub fn jwt_decoding_key_from_cert(cert: &[u8]) -> Result<jsonwebtoken::DecodingKey, Error> {
     let pem = pem::parse(cert).map_err(|_| Error::AuthlyCA("invalid authly certificate"))?;
 
     let (_, x509_cert) = x509_parser::parse_x509_certificate(pem.contents())

--- a/crates/authly-client/src/connection.rs
+++ b/crates/authly-client/src/connection.rs
@@ -1,0 +1,70 @@
+use std::{borrow::Cow, sync::Arc};
+
+use authly_common::proto::service::authly_service_client::AuthlyServiceClient;
+use tonic::transport::Endpoint;
+
+use crate::{
+    builder::{ConnectionParamsBuilder, Inference},
+    error,
+    identity::Identity,
+    Error,
+};
+
+pub(crate) struct Connection {
+    pub authly_service: AuthlyServiceClient<tonic::transport::Channel>,
+    pub params: Arc<ConnectionParams>,
+}
+
+#[derive(Clone)]
+pub(crate) enum ReconfigureStrategy {
+    ReInfer { url: Cow<'static, str> },
+    Params(Arc<ConnectionParams>),
+}
+
+impl ReconfigureStrategy {
+    pub(crate) async fn new_connection_params(&self) -> Result<Arc<ConnectionParams>, Error> {
+        match self {
+            Self::ReInfer { url } => {
+                let mut params_builder = ConnectionParamsBuilder::new(url.clone());
+                params_builder.infer().await?;
+                Ok(params_builder.try_into_connection_params()?)
+            }
+            Self::Params(params) => Ok(params.clone()),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ConnectionParams {
+    pub inference: Inference,
+    pub url: Cow<'static, str>,
+    pub authly_local_ca: Vec<u8>,
+    pub identity: Identity,
+    pub jwt_decoding_key: jsonwebtoken::DecodingKey,
+}
+
+pub async fn make_connection(params: Arc<ConnectionParams>) -> Result<Connection, Error> {
+    let tls_config = tonic::transport::ClientTlsConfig::new()
+        .ca_certificate(tonic::transport::Certificate::from_pem(
+            &params.authly_local_ca,
+        ))
+        .identity(tonic::transport::Identity::from_pem(
+            params.identity.cert_pem.clone(),
+            params.identity.key_pem.clone(),
+        ));
+
+    let endpoint = match &params.url {
+        Cow::Borrowed(url) => Endpoint::from_static(url),
+        Cow::Owned(url) => Endpoint::from_shared(url.clone()).map_err(error::network)?,
+    }
+    .tls_config(tls_config)
+    .map_err(error::network)?;
+
+    let authly_service =
+        AuthlyServiceClient::new(endpoint.connect().await.map_err(error::unclassified)?);
+
+    Ok(Connection {
+        authly_service,
+        params,
+    })
+}

--- a/crates/authly-client/src/identity.rs
+++ b/crates/authly-client/src/identity.rs
@@ -5,6 +5,7 @@ use crate::Error;
 /// Client identitity.
 ///
 /// All authly clients identifies themselves using mutual TLS.
+#[derive(Clone)]
 pub struct Identity {
     pub(crate) cert_pem: Vec<u8>,
     pub(crate) key_pem: Vec<u8>,

--- a/crates/authly-common/CHANGELOG.md
+++ b/crates/authly-common/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - mandate submission reponse type
 
+### Added
+- authly_service.proto: Add client messaging
+
 ## [0.0.4] - 2025-01-27
 ### Added
 - authly_connect and authly_mandate_submission services.

--- a/crates/authly-common/proto/authly_service.proto
+++ b/crates/authly-common/proto/authly_service.proto
@@ -18,6 +18,8 @@ service AuthlyService {
 
     // Make Authly sign the given certificate signing request using the local CA.
     rpc SignCertificate (CertificateSigningRequest) returns (Certificate);
+
+    rpc Messages (Empty) returns (stream ServiceMessage);
 }
 
 // Metadata about the service.
@@ -99,6 +101,21 @@ message CertificateSigningRequest {
 message Certificate {
     // The DER encoding of the certificate.
     bytes der = 1;
+}
+
+// An asynchronous message to the service that it should respond to.
+message ServiceMessage {
+    // The kind of message.
+    oneof ServiceMessageKind {
+        // The service should reload all Authly-related configuration including certificates,
+        // close and then re-open Authly connection.
+        //
+        // The reason for this might be renewed certificates, that the client has been dismissed by Authly, or other reasons.
+        Empty reload_ca = 1;
+
+        // The service should reload all locally cached data received through this gRPC service.
+        Empty reload_cache = 2;
+    }
 }
 
 // Represents no information being sent.

--- a/crates/authly-common/proto/authly_service.proto
+++ b/crates/authly-common/proto/authly_service.proto
@@ -19,7 +19,11 @@ service AuthlyService {
     // Make Authly sign the given certificate signing request using the local CA.
     rpc SignCertificate (CertificateSigningRequest) returns (Certificate);
 
+    // Subscribe to Authly messages.
     rpc Messages (Empty) returns (stream ServiceMessage);
+
+    // Respond to a ping.
+    rpc Pong (Empty) returns (Empty);
 }
 
 // Metadata about the service.
@@ -115,6 +119,9 @@ message ServiceMessage {
 
         // The service should reload all locally cached data received through this gRPC service.
         Empty reload_cache = 2;
+
+        // Authly tries to ping the service and the service should respond with invoking the `Pong` rpc.
+        Empty ping = 3;
     }
 }
 


### PR DESCRIPTION
Does mainly two things:

1. Add messaging protocol from Authly to Client.
2. Add a background worker task in the client to perform reconnection and react to messages