### PR TITLE
feat: Namespace metadata

### DIFF
--- a/crates/authly-client/CHANGELOG.md
+++ b/crates/authly-client/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Namespaces ("domains") added to access control API
+- Service metadata redesigned and moved to separate module.
 
 ## [0.0.5] - 2025-01-30
 ### Added

--- a/crates/authly-client/Cargo.toml
+++ b/crates/authly-client/Cargo.toml
@@ -16,7 +16,9 @@ reqwest_012 = []
 rustls_023 = ["dep:rustls"]
 
 [dependencies]
-authly-common = { path = "../authly-common", version = "0.0.5", features = ["access_token"] }
+authly-common = { path = "../authly-common", version = "0.0.5", features = [
+    "access_token",
+] }
 arc-swap = "1"
 anyhow = "1"
 fnv = "1"
@@ -33,6 +35,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 rustls = { version = "0.23", optional = true }
 rustls-pemfile = "2"
 rustls-pki-types = "1"
+serde_json = "1"
 thiserror = "2"
 time = "0.3"
 tonic = { version = "0.12", default-features = false, features = ["tls"] }

--- a/crates/authly-client/src/identity.rs
+++ b/crates/authly-client/src/identity.rs
@@ -1,3 +1,5 @@
+//! Client identity, in the TLS sense.
+
 use std::borrow::Cow;
 
 use pem::{EncodeConfig, Pem};

--- a/crates/authly-client/src/metadata.rs
+++ b/crates/authly-client/src/metadata.rs
@@ -1,0 +1,57 @@
+//! Client service metadata.
+
+use authly_common::id::Eid;
+
+/// A structure which provides various pieces of information about the service.
+///
+/// Metadata is not required for the service to function, but can be used optionally to
+/// convey application-specific data from the Authly database to the service.
+pub struct ServiceMetadata {
+    pub(crate) entity_id: Eid,
+
+    pub(crate) label: String,
+
+    pub(crate) namespaces: Vec<NamespaceMetadata>,
+}
+
+impl ServiceMetadata {
+    /// Get the entity ID ([Eid]) of the Authly service this client identifies as.
+    pub fn entity_id(&self) -> Eid {
+        self.entity_id
+    }
+
+    /// Get the label the service was given when registered in Authly.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Get the list of namespace metadata for the namespaces this service has access to.
+    ///
+    /// The list comes in no particular order and should be interpreted as a set.
+    pub fn namespaces(&self) -> &[NamespaceMetadata] {
+        &self.namespaces
+    }
+}
+
+/// Metadata about a namespace the service has access to.
+pub struct NamespaceMetadata {
+    pub(crate) label: String,
+    pub(crate) metadata: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+impl NamespaceMetadata {
+    /// The label of this namespace as configured in Authly.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Application-specific metadata of this namespace, encoded as a JSON map.
+    pub fn metadata(&self) -> Option<&serde_json::Map<String, serde_json::Value>> {
+        self.metadata.as_ref()
+    }
+
+    /// Application-specific metadata, owned version.
+    pub fn into_metadata(self) -> Option<serde_json::Map<String, serde_json::Value>> {
+        self.metadata
+    }
+}

--- a/crates/authly-client/src/token.rs
+++ b/crates/authly-client/src/token.rs
@@ -1,3 +1,5 @@
+//! Token utilities.
+
 use authly_common::access_token::AuthlyAccessTokenClaims;
 
 /// A verified access token, both in encoded and decoded format.

--- a/crates/authly-common/CHANGELOG.md
+++ b/crates/authly-common/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - decouple policies from services, introduce `domain` concept into document model.
 - improved implementation of policy engine with new logical model for policy combinations.
 - `entity-attribute-binding` renamed to `entity-attribute-assignment`. Now accepts only one parameter for identifying the entity.
+- Protobuf definitions changed into using `authly.` package prefix.
 
 ## [0.0.5] - 2025-01-30
 ### Changed

--- a/crates/authly-common/Cargo.toml
+++ b/crates/authly-common/Cargo.toml
@@ -33,6 +33,7 @@ http = { version = "1", optional = true }
 hyper = { version = "1", optional = true, default-features = false }
 int-enum = "1"
 prost = "0.13"
+prost-types = "0.13"
 rand = "0.8"
 rustls = { version = "0.23", optional = true, default-features = false }
 serde = { version = "1", features = ["derive"] }

--- a/crates/authly-common/build.rs
+++ b/crates/authly-common/build.rs
@@ -3,9 +3,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(
             &[
-                "proto/authly_connect.proto",
-                "proto/authly_mandate_submission.proto",
-                "proto/authly_service.proto",
+                "proto/authly/connect.proto",
+                "proto/authly/mandate_submission.proto",
+                "proto/authly/service.proto",
             ],
             &["proto/"],
         )?;

--- a/crates/authly-common/proto/authly/connect.proto
+++ b/crates/authly-common/proto/authly/connect.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package authly_connect;
+package authly.connect;
 
 // Authly Connect protocol
 service AuthlyConnect {

--- a/crates/authly-common/proto/authly/mandate_submission.proto
+++ b/crates/authly-common/proto/authly/mandate_submission.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package authly_mandate_submission;
+package authly.mandate_submission;
 
 // Authly Mandate Submission protocol.
 //

--- a/crates/authly-common/proto/authly/service.proto
+++ b/crates/authly-common/proto/authly/service.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
-package authly_service;
+package authly.service;
+
+import "google/protobuf/struct.proto";
 
 service AuthlyService {
     // Fetch metadata about the service using this API.
@@ -33,7 +35,24 @@ message ServiceMetadata {
 
     // The label given to this service.
     string label = 2;
+
+    // The namespaces available to this service.
+    repeated NamespaceMetadata namespaces = 3;
 }
+
+// Metadata about a namespace.
+message NamespaceMetadata {
+    // The Authly ID of this namespace.
+    bytes namespace_id = 1;
+
+    // The label given to this namespace.
+    string label = 2;
+
+    // Metadata stored in Authly about this namespace.
+    google.protobuf.Struct metadata = 3;
+}
+
+// Metadata about a service namespace.
 
 // An access token response.
 message AccessToken {

--- a/crates/authly-common/src/proto.rs
+++ b/crates/authly-common/src/proto.rs
@@ -2,15 +2,48 @@
 
 /// Tonic types for the `authly_connect` protobuf definition.
 pub mod connect {
-    tonic::include_proto!("authly_connect");
+    tonic::include_proto!("authly.connect");
 }
 
 /// Tonic types for the `authly_mandate_submission` protobuf definition.
 pub mod mandate_submission {
-    tonic::include_proto!("authly_mandate_submission");
+    tonic::include_proto!("authly.mandate_submission");
 }
 
 /// Tonic types for the `authly_service` protobuf definition.
 pub mod service {
-    tonic::include_proto!("authly_service");
+    tonic::include_proto!("authly.service");
+}
+
+/// Convert a protobuf Value to a JSON value.
+pub fn proto_value_to_json(value: prost_types::Value) -> serde_json::Value {
+    use prost_types::value::Kind;
+    use serde_json::Value;
+
+    match value.kind {
+        Some(Kind::NullValue(_)) => Value::Null,
+        Some(Kind::NumberValue(n)) => serde_json::Number::from_f64(n)
+            .map(Value::Number)
+            .unwrap_or(Value::Null),
+        Some(Kind::StringValue(s)) => Value::String(s),
+        Some(Kind::BoolValue(b)) => Value::Bool(b),
+        Some(Kind::StructValue(s)) => Value::Object(proto_struct_to_json(s)),
+        Some(Kind::ListValue(l)) => {
+            Value::Array(l.values.into_iter().map(proto_value_to_json).collect())
+        }
+        None => serde_json::Value::Null,
+    }
+}
+
+/// Convert a protobuf Struct to a JSON value.
+pub fn proto_struct_to_json(
+    proto: prost_types::Struct,
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut map = serde_json::Map::default();
+
+    for (key, value) in proto.fields {
+        map.insert(key, proto_value_to_json(value));
+    }
+
+    map
 }


### PR DESCRIPTION
* Move authly-client metadata-related things into module
* Clean up proto files, put in "namespace" folder
* Uses well-known protos (Value, Struct) from prost-types