### PR TITLE
feat: Client may set its own common name, support multiple alternative names (DNS hosts)

### DIFF
--- a/crates/authly-client/CHANGELOG.md
+++ b/crates/authly-client/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make access control test-friendly with dynamically-dispatched `AccessControl` trait.
 - `NamespacedPropertyAttribute` trait for making less verbose access control requests.
 - `request_client_builder_stream` not async anymore.
+- CSR API changed to accept any common name and explicit list of alternative names
 
 ### Added
 - `ConnectionParams` now public, and added a stream of `Arc<ConnectionParam>` to the Client API.

--- a/crates/authly-client/src/connection.rs
+++ b/crates/authly-client/src/connection.rs
@@ -2,7 +2,7 @@
 
 use std::{borrow::Cow, sync::Arc};
 
-use authly_common::proto::service::authly_service_client::AuthlyServiceClient;
+use authly_common::{id::Eid, proto::service::authly_service_client::AuthlyServiceClient};
 use tonic::transport::Endpoint;
 
 use crate::{
@@ -19,6 +19,7 @@ pub struct ConnectionParams {
     pub(crate) url: Cow<'static, str>,
     pub(crate) authly_local_ca: Vec<u8>,
     pub(crate) identity: Identity,
+    pub(crate) entity_id: Eid,
     pub(crate) jwt_decoding_key: jsonwebtoken::DecodingKey,
 }
 

--- a/crates/authly-client/src/error.rs
+++ b/crates/authly-client/src/error.rs
@@ -31,8 +31,8 @@ pub enum Error {
     EnvironmentNotInferrable,
 
     /// Invalid Common Name in certificate signing request.
-    #[error("invalid X509 common name")]
-    InvalidCommonName,
+    #[error("invalid X509 alt names")]
+    InvalidAltNames,
 
     /// A party was not authenticated or an operation was forbidden.
     #[error("unauthorized: {0}")]

--- a/crates/authly-client/src/identity.rs
+++ b/crates/authly-client/src/identity.rs
@@ -1,7 +1,8 @@
 //! Client identity, in the TLS sense.
 
-use std::borrow::Cow;
+use std::{borrow::Cow, str::FromStr};
 
+use authly_common::id::Eid;
 use pem::{EncodeConfig, Pem};
 
 use crate::Error;
@@ -77,4 +78,41 @@ impl Identity {
         identity_pem.extend(&self.key_pem);
         Ok(Cow::Owned(identity_pem))
     }
+}
+
+#[derive(Clone)]
+pub(crate) struct IdentityData {
+    pub entity_id: Eid,
+}
+
+pub(crate) fn parse_identity_data(cert: &[u8]) -> Result<IdentityData, Error> {
+    let pem = pem::parse(cert).map_err(|_| Error::AuthlyCA("invalid authly certificate"))?;
+
+    let (_, x509_cert) = x509_parser::parse_x509_certificate(pem.contents())
+        .map_err(|_| Error::AuthlyCA("invalid authly certificate"))?;
+
+    let mut entity_id: Option<Eid> = None;
+
+    for subject_attr in x509_cert.subject().iter_attributes() {
+        if let Some(oid_iter) = subject_attr.attr_type().iter() {
+            if oid_iter.eq(authly_common::certificate::oid::ENTITY_UNIQUE_IDENTIFIER
+                .iter()
+                .copied())
+            {
+                let value = subject_attr
+                    .attr_value()
+                    .as_str()
+                    .map_err(|_| Error::Identity("Entity Id value encoding"))?;
+                entity_id = Some(
+                    Eid::from_str(value)
+                        .map_err(|_| Error::Identity("Entity Id value encoding"))?,
+                );
+            }
+        }
+    }
+
+    let entity_id = entity_id.ok_or_else(|| Error::Identity("Entity Id is missing"))?;
+
+    // Assume that EC is always used
+    Ok(IdentityData { entity_id })
 }

--- a/crates/authly-common/CHANGELOG.md
+++ b/crates/authly-common/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `entity-attribute-binding` renamed to `entity-attribute-assignment`. Now accepts only one parameter for identifying the entity.
 - Protobuf definitions changed into using `authly.` package prefix.
 
+### Added
+- x509 oid extension for Entity ID
+
 ## [0.0.5] - 2025-01-30
 ### Changed
 - mandate submission reponse type

--- a/crates/authly-common/src/certificate.rs
+++ b/crates/authly-common/src/certificate.rs
@@ -1,0 +1,9 @@
+//! Authly Certificate extensions
+
+/// x509 Object Identifier extension
+pub mod oid {
+    /// Represents the entity ID of Authly services.
+    ///
+    /// reference: https://oid-base.com/get/2.5.4.45
+    pub const ENTITY_UNIQUE_IDENTIFIER: &[u64] = &[2, 5, 4, 45];
+}

--- a/crates/authly-common/src/lib.rs
+++ b/crates/authly-common/src/lib.rs
@@ -8,6 +8,7 @@ use std::{fmt::Display, marker::PhantomData, str::FromStr};
 
 use serde::de::{Error, Visitor};
 
+pub mod certificate;
 pub mod id;
 pub mod property;
 pub mod proto;


### PR DESCRIPTION
Common Name can later be used to identify different roles of the same service.