### PR TITLE
feat: Entity ID polymorphism

### DIFF
--- a/crates/authly-client/src/access_control.rs
+++ b/crates/authly-client/src/access_control.rs
@@ -3,7 +3,7 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use authly_common::{
-    id::{AttrId, Eid, Id128DynamicArrayConv},
+    id::{AttrId, EntityId, Id128DynamicArrayConv},
     proto::service::{self as proto, authly_service_client::AuthlyServiceClient},
     service::{NamespacePropertyMapping, NamespacedPropertyAttribute},
 };
@@ -37,7 +37,7 @@ pub struct AccessControlRequestBuilder<'c> {
     property_mapping: Arc<NamespacePropertyMapping>,
     access_token: Option<Arc<AccessToken>>,
     resource_attributes: FnvHashSet<AttrId>,
-    peer_entity_ids: FnvHashSet<Eid>,
+    peer_entity_ids: FnvHashSet<EntityId>,
 }
 
 impl<'c> AccessControlRequestBuilder<'c> {
@@ -103,7 +103,7 @@ impl<'c> AccessControlRequestBuilder<'c> {
     }
 
     /// Add a peer entity ID, which represents a client acting as a subject in the access control request.
-    pub fn peer_entity_id(mut self, entity_id: Eid) -> Self {
+    pub fn peer_entity_id(mut self, entity_id: EntityId) -> Self {
         self.peer_entity_ids.insert(entity_id);
         self
     }

--- a/crates/authly-client/src/connection.rs
+++ b/crates/authly-client/src/connection.rs
@@ -2,7 +2,7 @@
 
 use std::{borrow::Cow, sync::Arc};
 
-use authly_common::{id::Eid, proto::service::authly_service_client::AuthlyServiceClient};
+use authly_common::{id::ServiceId, proto::service::authly_service_client::AuthlyServiceClient};
 use tonic::transport::Endpoint;
 
 use crate::{
@@ -19,7 +19,7 @@ pub struct ConnectionParams {
     pub(crate) url: Cow<'static, str>,
     pub(crate) authly_local_ca: Vec<u8>,
     pub(crate) identity: Identity,
-    pub(crate) entity_id: Eid,
+    pub(crate) entity_id: ServiceId,
     pub(crate) jwt_decoding_key: jsonwebtoken::DecodingKey,
 }
 

--- a/crates/authly-client/src/identity.rs
+++ b/crates/authly-client/src/identity.rs
@@ -2,7 +2,7 @@
 
 use std::{borrow::Cow, str::FromStr};
 
-use authly_common::id::Eid;
+use authly_common::id::ServiceId;
 use pem::{EncodeConfig, Pem};
 
 use crate::Error;
@@ -82,7 +82,7 @@ impl Identity {
 
 #[derive(Clone)]
 pub(crate) struct IdentityData {
-    pub entity_id: Eid,
+    pub entity_id: ServiceId,
 }
 
 pub(crate) fn parse_identity_data(cert: &[u8]) -> Result<IdentityData, Error> {
@@ -91,7 +91,7 @@ pub(crate) fn parse_identity_data(cert: &[u8]) -> Result<IdentityData, Error> {
     let (_, x509_cert) = x509_parser::parse_x509_certificate(pem.contents())
         .map_err(|_| Error::AuthlyCA("invalid authly certificate"))?;
 
-    let mut entity_id: Option<Eid> = None;
+    let mut entity_id: Option<ServiceId> = None;
 
     for subject_attr in x509_cert.subject().iter_attributes() {
         if let Some(oid_iter) = subject_attr.attr_type().iter() {
@@ -104,7 +104,7 @@ pub(crate) fn parse_identity_data(cert: &[u8]) -> Result<IdentityData, Error> {
                     .as_str()
                     .map_err(|_| Error::Identity("Entity Id value encoding"))?;
                 entity_id = Some(
-                    Eid::from_str(value)
+                    ServiceId::from_str(value)
                         .map_err(|_| Error::Identity("Entity Id value encoding"))?,
                 );
             }

--- a/crates/authly-client/src/lib.rs
+++ b/crates/authly-client/src/lib.rs
@@ -25,7 +25,7 @@ use std::{borrow::Cow, sync::Arc, time::Duration};
 use anyhow::anyhow;
 use authly_common::{
     access_token::AuthlyAccessTokenClaims,
-    id::{Eid, Id128DynamicArrayConv},
+    id::{Id128DynamicArrayConv, ServiceId},
     proto::{
         proto_struct_to_json,
         service::{self as proto, authly_service_client::AuthlyServiceClient},
@@ -116,7 +116,8 @@ impl Client {
             .into_inner();
 
         Ok(ServiceMetadata {
-            entity_id: Eid::try_from_bytes_dynamic(&proto.entity_id).ok_or_else(id_codec_error)?,
+            entity_id: ServiceId::try_from_bytes_dynamic(&proto.entity_id)
+                .ok_or_else(id_codec_error)?,
             label: proto.label,
             namespaces: proto
                 .namespaces
@@ -175,7 +176,7 @@ impl Client {
         .boxed())
     }
 
-    /// Get the current resource properties of this service, in the form of a [PropertyMapping].
+    /// Get the current resource properties of this service, in the form of a [NamespacePropertyMapping].
     pub fn get_resource_property_mapping(&self) -> Arc<NamespacePropertyMapping> {
         self.state.resource_property_mapping.load_full()
     }

--- a/crates/authly-client/src/metadata.rs
+++ b/crates/authly-client/src/metadata.rs
@@ -1,13 +1,13 @@
 //! Client service metadata.
 
-use authly_common::id::Eid;
+use authly_common::id::ServiceId;
 
 /// A structure which provides various pieces of information about the service.
 ///
 /// Metadata is not required for the service to function, but can be used optionally to
 /// convey application-specific data from the Authly database to the service.
 pub struct ServiceMetadata {
-    pub(crate) entity_id: Eid,
+    pub(crate) entity_id: ServiceId,
 
     pub(crate) label: String,
 
@@ -15,8 +15,8 @@ pub struct ServiceMetadata {
 }
 
 impl ServiceMetadata {
-    /// Get the entity ID ([Eid]) of the Authly service this client identifies as.
-    pub fn entity_id(&self) -> Eid {
+    /// Get the entity ID ([ServiceId]) of the Authly service this client identifies as.
+    pub fn entity_id(&self) -> ServiceId {
         self.entity_id
     }
 

--- a/crates/authly-common/CHANGELOG.md
+++ b/crates/authly-common/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - improved implementation of policy engine with new logical model for policy combinations.
 - `entity-attribute-binding` renamed to `entity-attribute-assignment`. Now accepts only one parameter for identifying the entity.
 - Protobuf definitions changed into using `authly.` package prefix.
+- `Eid` removed, replaced by `PersonaId`, `GroupId`, `ServiceId` and their dynamic union: `EntityId`.
 
 ### Added
 - x509 oid extension for Entity ID

--- a/crates/authly-common/Cargo.toml
+++ b/crates/authly-common/Cargo.toml
@@ -48,7 +48,6 @@ tonic = { version = "0.12", default-features = false, features = [
 ] }
 tower-server = { version = "0.3", optional = true }
 tracing = "0.1"
-unsigned-varint = "0.8"
 uuid = { version = "1", features = ["serde", "v4"], optional = true }
 x509-parser = { version = "0.16", optional = true }
 

--- a/crates/authly-common/src/access_token.rs
+++ b/crates/authly-common/src/access_token.rs
@@ -3,7 +3,7 @@
 use fnv::FnvHashSet;
 use serde::{Deserialize, Serialize};
 
-use crate::id::{AttrId, Eid};
+use crate::id::{AttrId, EntityId};
 
 /// Claims for the Authly Access Token JWT
 #[derive(Serialize, Deserialize, Debug)]
@@ -23,8 +23,8 @@ pub struct AuthlyAccessTokenClaims {
 /// The authly claim.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Authly {
-    /// The [Eid] of the entity the access token was issued for.
-    pub entity_id: Eid,
+    /// The [EntityId] of the entity the access token was issued for.
+    pub entity_id: EntityId,
 
     /// The entity attributes at the time the token was issued.
     pub entity_attributes: FnvHashSet<AttrId>,

--- a/crates/authly-common/src/certificate.rs
+++ b/crates/authly-common/src/certificate.rs
@@ -4,6 +4,6 @@
 pub mod oid {
     /// Represents the entity ID of Authly services.
     ///
-    /// reference: https://oid-base.com/get/2.5.4.45
+    /// reference: [iod-base.com](https://oid-base.com/get/2.5.4.45)
     pub const ENTITY_UNIQUE_IDENTIFIER: &[u64] = &[2, 5, 4, 45];
 }

--- a/crates/authly-common/src/document.rs
+++ b/crates/authly-common/src/document.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use toml::Spanned;
 use uuid::Uuid;
 
-use crate::{id::Eid, property::QualifiedAttributeName};
+use crate::{id::EntityId, property::QualifiedAttributeName};
 
 /// The deserialized representation of an authly document.
 #[derive(Deserialize)]
@@ -73,8 +73,8 @@ pub type DynamicObject = serde_json::Map<String, serde_json::Value>;
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Entity {
-    /// The eid of this entity.
-    pub eid: Spanned<Eid>,
+    /// The id of this entity.
+    pub eid: Spanned<EntityId>,
 
     /// A label for the entity visible in the document namespace.
     #[serde(default)]

--- a/crates/authly-common/src/mtls_server.rs
+++ b/crates/authly-common/src/mtls_server.rs
@@ -5,11 +5,11 @@ use hyper::body::Incoming;
 use tracing::warn;
 use x509_parser::prelude::{FromDer, X509Certificate};
 
-use crate::{certificate::oid::ENTITY_UNIQUE_IDENTIFIER, id::Eid};
+use crate::{certificate::oid::ENTITY_UNIQUE_IDENTIFIER, id::ServiceId};
 
 /// A [Request] extension representing the peer Authly service that connected to the local server.
 #[derive(Clone, Copy, Debug)]
-pub struct PeerServiceEntity(pub Eid);
+pub struct PeerServiceEntity(pub ServiceId);
 
 /// A middleware for setting up mTLS with [tower_server].
 #[derive(Clone)]
@@ -18,7 +18,7 @@ pub struct MTLSMiddleware;
 /// The
 #[derive(Default)]
 pub struct MTLSConnectionData {
-    peer_service_entity: Option<Eid>,
+    peer_service_entity: Option<ServiceId>,
 }
 
 impl tower_server::tls::TlsConnectionMiddleware for MTLSMiddleware {

--- a/crates/authly-common/src/policy/code.rs
+++ b/crates/authly-common/src/policy/code.rs
@@ -82,20 +82,14 @@ pub fn to_bytecode(opcodes: &[OpCode]) -> Vec<u8> {
         match opcode {
             OpCode::LoadSubjectId(prop_id) => {
                 out.push(Bytecode::LoadSubjectId as u8);
-                out.extend(unsigned_varint::encode::u128(
-                    prop_id.to_uint(),
-                    &mut Default::default(),
-                ));
+                out.extend(prop_id.to_raw_array());
             }
             OpCode::LoadSubjectAttrs => {
                 out.push(Bytecode::LoadSubjectAttrs as u8);
             }
             OpCode::LoadResourceId(prop_id) => {
                 out.push(Bytecode::LoadResourceId as u8);
-                out.extend(unsigned_varint::encode::u128(
-                    prop_id.to_uint(),
-                    &mut Default::default(),
-                ));
+                out.extend(prop_id.to_raw_array());
             }
             OpCode::LoadResourceAttrs => {
                 out.push(Bytecode::LoadResourceAttrs as u8);
@@ -103,17 +97,11 @@ pub fn to_bytecode(opcodes: &[OpCode]) -> Vec<u8> {
             OpCode::LoadConstEntityId(eid) => {
                 out.push(Bytecode::LoadConstEntityId as u8);
                 out.push(eid.kind().into());
-                out.extend(unsigned_varint::encode::u128(
-                    u128::from_be_bytes(eid.id),
-                    &mut Default::default(),
-                ));
+                out.extend(eid.id);
             }
             OpCode::LoadConstAttrId(prop_id) => {
                 out.push(Bytecode::LoadConstAttrId as u8);
-                out.extend(unsigned_varint::encode::u128(
-                    prop_id.to_uint(),
-                    &mut Default::default(),
-                ));
+                out.extend(prop_id.to_raw_array());
             }
             OpCode::IsEq => {
                 out.push(Bytecode::IsEq as u8);

--- a/crates/authly-common/src/policy/code.rs
+++ b/crates/authly-common/src/policy/code.rs
@@ -3,6 +3,8 @@
 use int_enum::IntEnum;
 use serde::{Deserialize, Serialize};
 
+use crate::id::{AttrId, EntityId, PropId};
+
 /// The value/outcome of a policy engine evaluation.
 #[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
 pub enum PolicyValue {
@@ -37,12 +39,12 @@ impl From<bool> for PolicyValue {
 #[derive(PartialEq, Eq, Debug)]
 #[allow(missing_docs)]
 pub enum OpCode {
-    LoadSubjectId(u128),
+    LoadSubjectId(PropId),
     LoadSubjectAttrs,
-    LoadResourceId(u128),
+    LoadResourceId(PropId),
     LoadResourceAttrs,
-    LoadConstEntityId(u128),
-    LoadConstAttrId(u128),
+    LoadConstEntityId(EntityId),
+    LoadConstAttrId(AttrId),
     IsEq,
     SupersetOf,
     IdSetContains,
@@ -78,27 +80,40 @@ pub fn to_bytecode(opcodes: &[OpCode]) -> Vec<u8> {
 
     for opcode in opcodes {
         match opcode {
-            OpCode::LoadSubjectId(eid) => {
+            OpCode::LoadSubjectId(prop_id) => {
                 out.push(Bytecode::LoadSubjectId as u8);
-                out.extend(unsigned_varint::encode::u128(*eid, &mut Default::default()));
+                out.extend(unsigned_varint::encode::u128(
+                    prop_id.to_uint(),
+                    &mut Default::default(),
+                ));
             }
             OpCode::LoadSubjectAttrs => {
                 out.push(Bytecode::LoadSubjectAttrs as u8);
             }
-            OpCode::LoadResourceId(eid) => {
+            OpCode::LoadResourceId(prop_id) => {
                 out.push(Bytecode::LoadResourceId as u8);
-                out.extend(unsigned_varint::encode::u128(*eid, &mut Default::default()));
+                out.extend(unsigned_varint::encode::u128(
+                    prop_id.to_uint(),
+                    &mut Default::default(),
+                ));
             }
             OpCode::LoadResourceAttrs => {
                 out.push(Bytecode::LoadResourceAttrs as u8);
             }
-            OpCode::LoadConstEntityId(id) => {
+            OpCode::LoadConstEntityId(eid) => {
                 out.push(Bytecode::LoadConstEntityId as u8);
-                out.extend(unsigned_varint::encode::u128(*id, &mut Default::default()));
+                out.push(eid.kind().into());
+                out.extend(unsigned_varint::encode::u128(
+                    u128::from_be_bytes(eid.id),
+                    &mut Default::default(),
+                ));
             }
-            OpCode::LoadConstAttrId(id) => {
+            OpCode::LoadConstAttrId(prop_id) => {
                 out.push(Bytecode::LoadConstAttrId as u8);
-                out.extend(unsigned_varint::encode::u128(*id, &mut Default::default()));
+                out.extend(unsigned_varint::encode::u128(
+                    prop_id.to_uint(),
+                    &mut Default::default(),
+                ));
             }
             OpCode::IsEq => {
                 out.push(Bytecode::IsEq as u8);

--- a/crates/authly-common/src/policy/engine.rs
+++ b/crates/authly-common/src/policy/engine.rs
@@ -2,10 +2,11 @@
 
 use std::collections::BTreeSet;
 
+use byteorder::{BigEndian, ReadBytesExt};
 use fnv::{FnvHashMap, FnvHashSet};
 use tracing::error;
 
-use crate::id::{kind::Kind, AttrId, EntityId, Id128, PolicyId, PropId};
+use crate::id::{kind::Kind, AttrId, EntityId, PolicyId, PropId};
 
 use super::code::{Bytecode, PolicyValue};
 
@@ -292,42 +293,35 @@ fn eval_policy(mut pc: &[u8], params: &AccessControlParams) -> Result<bool, Eval
 
         match code {
             Bytecode::LoadSubjectId => {
-                let (key, next) = decode_id(pc)?;
-                let Some(id) = params.subject_eids.get(&key) else {
+                let prop_id = PropId::from_uint(pc.read_u128::<BigEndian>()?);
+                let Some(id) = params.subject_eids.get(&prop_id) else {
                     return Err(EvalError::Type);
                 };
                 stack.push(StackItem::EntityId(*id));
-                pc = next;
             }
             Bytecode::LoadSubjectAttrs => {
                 stack.push(StackItem::AttrIdSet(&params.subject_attrs));
             }
             Bytecode::LoadResourceId => {
-                let (key, next) = decode_id(pc)?;
-                let Some(id) = params.resource_eids.get(&key) else {
+                let prop_id = PropId::from_uint(pc.read_u128::<BigEndian>()?);
+                let Some(id) = params.resource_eids.get(&prop_id) else {
                     return Err(EvalError::Type);
                 };
                 stack.push(StackItem::EntityId(*id));
-                pc = next;
             }
             Bytecode::LoadResourceAttrs => {
                 stack.push(StackItem::AttrIdSet(&params.resource_attrs));
             }
             Bytecode::LoadConstEntityId => {
-                let Ok(kind) = Kind::try_from(pc[0]) else {
+                let Ok(kind) = Kind::try_from(pc.read_u8()?) else {
                     return Err(EvalError::Type);
                 };
-                pc = &pc[1..];
-
-                let (uint, next) =
-                    unsigned_varint::decode::u128(pc).map_err(|_| EvalError::Program)?;
+                let uint = pc.read_u128::<BigEndian>()?;
                 stack.push(StackItem::EntityId(EntityId::new(kind, uint.to_be_bytes())));
-                pc = next;
             }
             Bytecode::LoadConstAttrId => {
-                let (id, next) = decode_id(pc)?;
-                stack.push(StackItem::AttrId(id));
-                pc = next;
+                let attr_id = AttrId::from_uint(pc.read_u128::<BigEndian>()?);
+                stack.push(StackItem::AttrId(attr_id));
             }
             Bytecode::IsEq => {
                 let Some(a) = stack.pop() else {
@@ -408,9 +402,8 @@ fn eval_policy(mut pc: &[u8], params: &AccessControlParams) -> Result<bool, Eval
     Err(EvalError::Program)
 }
 
-#[inline]
-fn decode_id<K>(buf: &[u8]) -> Result<(Id128<K>, &[u8]), EvalError> {
-    let (uint, next) = unsigned_varint::decode::u128(buf).map_err(|_| EvalError::Program)?;
-
-    Ok((Id128::from_uint(uint), next))
+impl From<std::io::Error> for EvalError {
+    fn from(_value: std::io::Error) -> Self {
+        EvalError::Program
+    }
 }

--- a/crates/authly-common/tests/integration/test_document.rs
+++ b/crates/authly-common/tests/integration/test_document.rs
@@ -6,7 +6,7 @@ const ENTITY: &str = r#"
 id = "d783648f-e6ac-4492-87f7-43d5e5805d60"
 
 [[entity]]
-eid = "e.7d8b18fa5836487592a43eacea830b47"
+eid = "p.7d8b18fa5836487592a43eacea830b47"
 label = "me"
 email = ["me@mail.com"]
 username = "testuser"
@@ -20,7 +20,7 @@ const SVC: &str = r#"
 id = "bc9ce588-50c3-47d1-94c1-f88b21eaf299"
 
 [[service-entity]]
-eid = "e.2671d2a0bc3545e69fc666130254f8e9"
+eid = "s.2671d2a0bc3545e69fc666130254f8e9"
 label = "testservice"
 attributes = ["authly:role:authenticate", "authly:role:get_access_token"]
 kubernetes-account = { name = "testservice", namespace = "authly-test" }
@@ -31,7 +31,7 @@ label = "role"
 attributes = ["ui/user", "ui/admin"]
 
 [[entity-attribute-assignment]]
-entity = "e.7d8b18fa5836487592a43eacea830b47"
+entity = "s.7d8b18fa5836487592a43eacea830b47"
 attributes = ["testservice:role:ui/user"]
 
 [[resource-property]]
@@ -94,7 +94,7 @@ const METADATA: &str = r#"
 id = "d783648f-e6ac-4492-87f7-43d5e5805d60"
 
 [[service-entity]]
-eid = "e.2671d2a0bc3545e69fc666130254f8e9"
+eid = "s.2671d2a0bc3545e69fc666130254f8e9"
 label = "testservice"
 metadata = { description = "just for testing" }
 
@@ -113,7 +113,7 @@ fn test_entity() {
     assert_eq!(&toml[24..62], "\"d783648f-e6ac-4492-87f7-43d5e5805d60\"");
 
     assert_eq!(document.entity[0].eid.span(), 81..117);
-    assert_eq!(&toml[81..117], "\"e.7d8b18fa5836487592a43eacea830b47\"");
+    assert_eq!(&toml[81..117], "\"p.7d8b18fa5836487592a43eacea830b47\"");
 
     assert_eq!(document.entity.len(), 1);
 }

--- a/crates/authly-common/tests/integration/test_policies.rs
+++ b/crates/authly-common/tests/integration/test_policies.rs
@@ -24,8 +24,8 @@ const EXTRA: AttrId = AttrId::from_uint(42);
 
 fn true_policy() -> Vec<u8> {
     to_bytecode(&[
-        OpCode::LoadConstAttrId(0),
-        OpCode::LoadConstAttrId(0),
+        OpCode::LoadConstAttrId(AttrId::from_uint(0)),
+        OpCode::LoadConstAttrId(AttrId::from_uint(0)),
         OpCode::IsEq,
         OpCode::Return,
     ])
@@ -33,8 +33,8 @@ fn true_policy() -> Vec<u8> {
 
 fn false_policy() -> Vec<u8> {
     to_bytecode(&[
-        OpCode::LoadConstAttrId(0),
-        OpCode::LoadConstAttrId(1),
+        OpCode::LoadConstAttrId(AttrId::from_uint(0)),
+        OpCode::LoadConstAttrId(AttrId::from_uint(1)),
         OpCode::IsEq,
         OpCode::Return,
     ])


### PR DESCRIPTION
Introduce 3 new distinct ID types:
* `PersonaId` (`p.XXXX...`)
* `GroupId`  (`g.XXXX....`)
* `ServiceId` (`s.XXXX....`)

and their dynamic union: `EntityId`.

Clean up `OpCode` enum to make sure it is strongly typed with no chance of data loss.