### PR TITLE
feat: configuration and hosts

### DIFF
--- a/crates/authly-client/CHANGELOG.md
+++ b/crates/authly-client/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## Changed
+- Server certificate alt names now comes from Authly instead of being specified by the service.
+
 ### Fixed
 - Turn off `rustls` default features.
 

--- a/crates/authly-common/CHANGELOG.md
+++ b/crates/authly-common/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- added `GetConfiguration` to authly service proto, replaces `GetResourcePropertyMappings`.
+
 ### Added
 - public method to get peer service entity from MTLSMiddleware when not used with HTTP
 

--- a/crates/authly-common/proto/authly/service.proto
+++ b/crates/authly-common/proto/authly/service.proto
@@ -4,6 +4,9 @@ package authly.service;
 import "google/protobuf/struct.proto";
 
 service AuthlyService {
+    // Fetch the configuration of this service.
+    rpc GetConfiguration (Empty) returns (ServiceConfiguration);
+
     // Fetch metadata about the service using this API.
     rpc GetMetadata (Empty) returns (ServiceMetadata);
 
@@ -11,7 +14,7 @@ service AuthlyService {
     // The session info is passed as Authorization header or cookie.
     rpc GetAccessToken (Empty) returns (AccessToken);
 
-    // Get the current property mapping for the service.
+    // Get the current property mapping for the service (deprecated, use GetConfiguration).
     rpc GetResourcePropertyMappings (Empty) returns (PropertyMappingsResponse);
 
     // Perform remote access control.
@@ -28,7 +31,21 @@ service AuthlyService {
     rpc Pong (Empty) returns (Empty);
 }
 
+// Service configuration.
+//
+// Important information for the service to function.
+message ServiceConfiguration {
+    // Resource property mapping namespaces.
+    // Necessary for access control.
+    repeated PropertyMappingNamespace property_mapping_namespaces = 1;
+
+    // The hosts that can be used to reach this service.
+    repeated string hosts = 2;
+}
+
 // Metadata about the service.
+//
+// This information is less important than the ServiceConfiguration.
 message ServiceMetadata {
     // The entity ID of this service.
     bytes entity_id = 1;

--- a/crates/authly-common/src/document.rs
+++ b/crates/authly-common/src/document.rs
@@ -101,6 +101,10 @@ pub struct Entity {
     #[serde(default, rename = "password-hash")]
     pub password_hash: Vec<String>,
 
+    /// A list of service hostnames
+    #[serde(default)]
+    pub hosts: Vec<String>,
+
     /// An optional kubernetes account.
     #[serde(default, rename = "kubernetes-account")]
     pub kubernetes_account: Option<KubernetesAccount>,


### PR DESCRIPTION
`subject_alt_names` removed from client API, this was an insecure hack while lacking a more proper solution. Now instead `hosts` are specified per-service. Those hosts will be sent by Authly to each client, through `Configuration`. The hosts from the configuration are inserted into the server Certificate Signing Request. When Authly receives that request for signing, it verifies that those alt names are (still) a subset of the hostnames it knows about for that service.